### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build Check
+permissions:
+  contents: read
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/ruandev/capacidade-instalada-backend/security/code-scanning/3](https://github.com/ruandev/capacidade-instalada-backend/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents, we can set `contents: read` as the minimal permission. This block should be added at the root level of the workflow to apply to all jobs, as there is no indication that specific jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
