### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   code-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ruandev/capacidade-instalada-backend/security/code-scanning/1](https://github.com/ruandev/capacidade-instalada-backend/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and runs linting commands, it does not require write access. We will set `contents: read` as the permission, which is sufficient for these operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
