### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: Test and Coverage Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-and-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ruandev/capacidade-instalada-backend/security/code-scanning/2](https://github.com/ruandev/capacidade-instalada-backend/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the provided steps, the workflow only needs to read the repository contents to check out the code and run tests. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
